### PR TITLE
feat: add format option --

### DIFF
--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -37,6 +37,7 @@ var mergeDefaultOptions = function(options) {
         hourStep: 1,
         minuteStep: 1,
         meridiemPosition: 'right',
+        format: 'h:m',
         usageStatistics: true
     }, options);
 };
@@ -180,6 +181,13 @@ var TimePicker = snippet.defineClass(/** @lends TimePicker.prototype */ {
          */
         this._localeText = localeTexts[options.language];
 
+        /**
+         * Time format for output
+         * @type {string}
+         * @private
+         */
+        this._format = this._getValidTimeFormat(options.format);
+
         this._render();
         this._setEvents();
 
@@ -271,6 +279,7 @@ var TimePicker = snippet.defineClass(/** @lends TimePicker.prototype */ {
         var $hourElement = this._$element.find(SELECTOR_HOUR_ELELEMENT);
         var $minuteElement = this._$element.find(SELECTOR_MINUTE_ELELEMENT);
         var BoxComponent = this._inputType.toLowerCase() === 'selectbox' ? Selectbox : Spinbox;
+        var formatExplode = this._format.split(':');
 
         if (showMeridiem) {
             hour = util.getMeridiemHour(hour);
@@ -278,13 +287,29 @@ var TimePicker = snippet.defineClass(/** @lends TimePicker.prototype */ {
 
         this._hourInput = new BoxComponent($hourElement, {
             initialValue: hour,
-            items: this._getHourItems()
+            items: this._getHourItems(),
+            format: formatExplode[0]
         });
 
         this._minuteInput = new BoxComponent($minuteElement, {
             initialValue: this._minute,
-            items: this._getMinuteItems()
+            items: this._getMinuteItems(),
+            format: formatExplode[1]
         });
+    },
+
+    /**
+     * Return formatted format.
+     * @param {string} format - format option
+     * @returns {string}
+     * @private
+     */
+    _getValidTimeFormat: function(format) {
+        if (!format.match(/^[h]{1,2}:[m]{1,2}$/i)) {
+            return 'h:m';
+        }
+
+        return format.toLowerCase();
     },
 
     /**

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -51,6 +51,7 @@ var mergeDefaultOptions = function(options) {
  * @param {number} [options.hourStep = 1] - Step value of hour
  * @param {number} [options.minuteStep = 1] - Step value of minute
  * @param {string} [options.inputType = 'selectbox'] - 'selectbox' or 'spinbox'
+ * @param {string} [options.format = 'h:m'] - hour, minute format for display
  * @param {boolean} [options.showMeridiem = true] - Show meridiem expression?
  * @param {string} [options.meridiemPosition = 'right'] - Set location of the meridiem element.
  *                 If this option set 'left', the meridiem element is created in front of the hour element.

--- a/src/js/timepicker/selectbox.js
+++ b/src/js/timepicker/selectbox.js
@@ -46,6 +46,13 @@ var Selectbox = snippet.defineClass(/** @lends Selectbox.prototype */ {
         this._selectedIndex = Math.max(0, snippet.inArray(options.initialValue, this._items));
 
         /**
+         * Time format for output
+         * @type {string}
+         * @private
+         */
+        this._format = options.format;
+
+        /**
          * Element
          * @type {jQuery}
          * @private
@@ -63,7 +70,8 @@ var Selectbox = snippet.defineClass(/** @lends Selectbox.prototype */ {
     _render: function() {
         var context = {
             items: this._items,
-            initialValue: this.getValue()
+            initialValue: this.getValue(),
+            format: this._format
         };
 
         this._$element.remove();

--- a/src/js/timepicker/spinbox.js
+++ b/src/js/timepicker/spinbox.js
@@ -10,6 +10,7 @@ var $ = require('jquery');
 var snippet = require('tui-code-snippet');
 
 var tmpl = require('./../../template/timepicker/spinbox.hbs');
+var timeFormat = require('./../../template/helpers/timeFormat');
 
 var SELECTOR_UP_BUTTON = '.tui-timepicker-btn-up';
 var SELECTOR_DOWN_BUTTON = '.tui-timepicker-btn-down';
@@ -60,6 +61,13 @@ var Spinbox = snippet.defineClass(/** @lends Spinbox.prototype */ {
          */
         this._selectedIndex = Math.max(0, snippet.inArray(options.initialValue, this._items));
 
+        /**
+         * Time format for output
+         * @type {string}
+         * @private
+         */
+        this._format = options.format;
+
         this._render();
         this._setEvents();
     },
@@ -71,7 +79,8 @@ var Spinbox = snippet.defineClass(/** @lends Spinbox.prototype */ {
     _render: function() {
         var context = {
             maxLength: this._getMaxLength(),
-            initialValue: this.getValue()
+            initialValue: this.getValue(),
+            format: this._format
         };
 
         this._$element = $(tmpl(context));
@@ -174,7 +183,7 @@ var Spinbox = snippet.defineClass(/** @lends Spinbox.prototype */ {
      * @param {number} value - Value
      */
     setValue: function(value) {
-        this._$inputElement.val(value).change();
+        this._$inputElement.val(timeFormat(value, this._format)).change();
     },
 
     /**

--- a/src/template/helpers/timeFormat.js
+++ b/src/template/helpers/timeFormat.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Handlebars helper - Equals
+ * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
+ */
+
+'use strict';
+
+var PADDING_ZERO_TYPES = ['hh', 'mm'];
+
+/**
+ * @param {number} value time or minute
+ * @param {string} format - timeFormat
+ * @returns {boolean}
+ */
+module.exports = function(value, format) {
+    value = String(value);
+
+    return (PADDING_ZERO_TYPES.indexOf(format) >= 0 && value.length === 1) ? '0' + value : value;
+};

--- a/src/template/timepicker/selectbox.hbs
+++ b/src/template/timepicker/selectbox.hbs
@@ -1,9 +1,9 @@
 <select class="tui-timepicker-select" aria-label="Time">
     {{#each items as |item|}}
         {{#if ([../helpers/equals] ../initialValue item)}}
-            <option value="{{item}}" selected>{{item}}</option>
+            <option value="{{item}}" selected>{{[../helpers/timeFormat] item ../format}}</option>
         {{else}}
-            <option value="{{item}}">{{item}}</option>
+            <option value="{{item}}">{{[../helpers/timeFormat] item ../format}}</option>
         {{/if}}
     {{/each}}
 </select>

--- a/src/template/timepicker/spinbox.hbs
+++ b/src/template/timepicker/spinbox.hbs
@@ -2,7 +2,7 @@
     <input type="text" class="tui-timepicker-spinbox-input"
            maxlength="{{maxLength}}"
            size="{{maxLength}}"
-           value="{{initialValue}}"
+           value="{{[../helpers/timeFormat] initialValue format}}"
            aria-label="TimePicker spinbox value">
     <button type="button" class="tui-timepicker-btn tui-timepicker-btn-up">
         <span class="tui-ico-t-btn">Increase</span>

--- a/test/timepicker/selectbox.spec.js
+++ b/test/timepicker/selectbox.spec.js
@@ -15,7 +15,8 @@ describe('TimePicker - Selectbox', function() {
     beforeEach(function() {
         selectbox = new Selectbox($container, {
             initialValue: 4,
-            items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            format: 'hh'
         });
     });
 
@@ -28,6 +29,34 @@ describe('TimePicker - Selectbox', function() {
             var selectedIndex = selectbox._selectedIndex;
 
             expect(selectedIndex).toEqual(3);
+        });
+
+        it('should be output as zero padded double char when format is a "hh"', function() {
+            var expected;
+
+            selectbox.destroy();
+            selectbox = new Selectbox($container, {
+                initialValue: 4,
+                items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                format: 'hh'
+            });
+
+            expected = selectbox._$element.find('option:eq(0)').html();
+            expect(expected).toEqual('01');
+        });
+
+        it('should be output as single char when format is a "h"', function() {
+            var expected;
+
+            selectbox.destroy();
+            selectbox = new Selectbox($container, {
+                initialValue: 4,
+                items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                format: 'h'
+            });
+
+            expected = selectbox._$element.find('option:eq(0)').html();
+            expect(expected).toEqual('1');
         });
     });
 

--- a/test/timepicker/spinbox.spec.js
+++ b/test/timepicker/spinbox.spec.js
@@ -38,6 +38,34 @@ describe('TimePicker - Spinbox', function() {
             expect($inputEl.attr('size')).toEqual('2');
             expect($inputEl.attr('maxlength')).toEqual('2');
         });
+
+        it('should be output as zero padded double char when format is a "hh"', function() {
+            var expected;
+
+            spinbox.destroy();
+            spinbox = new Spinbox($container, {
+                initialValue: 4,
+                items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                format: 'hh'
+            });
+
+            expected = spinbox._$inputElement.val();
+            expect(expected).toEqual('04');
+        });
+
+        it('should be output as single char when format is a "h"', function() {
+            var expected;
+
+            spinbox.destroy();
+            spinbox = new Spinbox($container, {
+                initialValue: 4,
+                items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                format: 'h'
+            });
+
+            expected = spinbox._$inputElement.val();
+            expect(expected).toEqual('4');
+        });
     });
 
     describe('api', function() {


### PR DESCRIPTION
## work
- add time format option 한자리 시간에  zero padding을 붙여 2charactor로 만들어줌
- 메리디엄 옵션이 있기때문에 h의 대문자 옵션은 고려하지 않음 
```javascript
format: 'hh:mm'  // or 'h:m'
```

## demo
- http://10.78.9.21:8083/examples/example01-basic.html