### PR TITLE
fix: set events after rendering a selectbox (fix #37)

### DIFF
--- a/src/js/timepicker/selectbox.js
+++ b/src/js/timepicker/selectbox.js
@@ -99,10 +99,13 @@ var Selectbox = snippet.defineClass(
       };
 
       if (this._element) {
+        domUtil.off(this._element, 'change');
         domUtil.removeElement(this._element);
       }
+
       this._container.innerHTML = tmpl(context);
       this._element = this._container.firstChild;
+      domUtil.on(this._element, 'change', this._onChangeHandler, this);
     },
 
     /**
@@ -131,8 +134,6 @@ var Selectbox = snippet.defineClass(
      * @private
      */
     _setEvents: function() {
-      domUtil.on(this._element, 'change', this._onChangeHandler, this);
-
       this.on(
         'changeItems',
         function(items) {

--- a/src/js/timepicker/selectbox.js
+++ b/src/js/timepicker/selectbox.js
@@ -99,8 +99,7 @@ var Selectbox = snippet.defineClass(
       };
 
       if (this._element) {
-        domUtil.off(this._element, 'change');
-        domUtil.removeElement(this._element);
+        this._removeElement();
       }
 
       this._container.innerHTML = tmpl(context);
@@ -150,8 +149,15 @@ var Selectbox = snippet.defineClass(
      */
     _removeEvents: function() {
       this.off();
+    },
 
+    /**
+     * Remove element
+     * @private
+     */
+    _removeElement: function() {
       domUtil.off(this._element, 'change', this._onChangeHandler, this);
+      domUtil.removeElement(this._element);
     },
 
     /**
@@ -204,7 +210,7 @@ var Selectbox = snippet.defineClass(
      */
     destroy: function() {
       this._removeEvents();
-      domUtil.removeElement(this._element);
+      this._removeElement();
       this._container = this._items = this._selectedIndex = this._element = null;
     }
   }


### PR DESCRIPTION
## Bug Fix: https://github.com/nhn/tui.time-picker/issues/37
* 현재: selectbox timepicker에서 오전/오후를 바꾸면 hour의 업데이트가 되지 않음
* 원인: 오전/오후를 바꿈 -> hour element가 제거되었다가 다시 만들어짐 -> 이 때 `change` 이벤트가 다시 bind 되지 않음
* 해결: hour element를 다시 만들 때 `change` 이벤트를 다시 걸어준다.