### PR TITLE
fix: always reset time when setting range

### DIFF
--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -768,7 +768,9 @@ var TimePicker = defineClass(
      * @private
      */
     applyRange: function(beginHour, beginMin, endHour) {
-      this.setTime(beginHour, beginMin);
+      if (this.isLaterThanSettedTime(beginHour, beginMin)) {
+        this.setTime(beginHour, beginMin);
+      }
       this.setDisabledHours();
 
       if (this.showMeridiem) {
@@ -834,6 +836,17 @@ var TimePicker = defineClass(
       hour <= END_NUMBER_OF_HOUR &&
       minute >= START_NUMBER_OF_TIME &&
       minute <= END_NUMBER_OF_MINUTE;
+    },
+
+    /**
+     * Compare given time with setted time 
+     * @param {number} hour - given hour
+     * @param {number} minute - given minute
+     * @returns {boolean} result of compare
+     * @private
+     */
+    isLaterThanSettedTime: function(hour, minute) {
+      return hour > this.hour || (hour === this.hour && minute > this.minute);
     },
 
     /**

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -768,7 +768,7 @@ var TimePicker = defineClass(
      * @private
      */
     applyRange: function(beginHour, beginMin, endHour) {
-      if (this.isLaterThanSettedTime(beginHour, beginMin)) {
+      if (this.isLaterThanSetTime(beginHour, beginMin)) {
         this.setTime(beginHour, beginMin);
       }
       this.setDisabledHours();
@@ -839,13 +839,13 @@ var TimePicker = defineClass(
     },
 
     /**
-     * Compare given time with setted time 
+     * Compare given time with set time 
      * @param {number} hour - given hour
      * @param {number} minute - given minute
      * @returns {boolean} result of compare
      * @private
      */
-    isLaterThanSettedTime: function(hour, minute) {
+    isLaterThanSetTime: function(hour, minute) {
       return hour > this.hour || (hour === this.hour && minute > this.minute);
     },
 

--- a/test/timepicker/timepicker.spec.js
+++ b/test/timepicker/timepicker.spec.js
@@ -527,6 +527,26 @@ describe('Set selectable range', function() {
     expect(selectOptions).toMatchObject(unrangedMins);
   });
 
+  it('should set time to range begin if it is later than setted time', function() {
+    var start = makeRangeObj(10, 35);
+
+    timepickerNoMeridiem.setTime(9, 30);
+    timepickerNoMeridiem.setRange(start);
+
+    expect(timepickerNoMeridiem.getHour()).toBe(10);
+    expect(timepickerNoMeridiem.getMinute()).toBe(35);
+  });
+
+  it('should not reset time if the time which is begin of range is earlier than setted time', function() {
+    var start = makeRangeObj(8, 35);
+
+    timepickerNoMeridiem.setTime(9, 30);
+    timepickerNoMeridiem.setRange(start);
+
+    expect(timepickerNoMeridiem.getHour()).toBe(9);
+    expect(timepickerNoMeridiem.getMinute()).toBe(30);
+  });
+
   it('should disable a meridiem selector when range included in the other', function() {
     var start = makeRangeObj(6, 30);
     var end = makeRangeObj(11, 30);

--- a/test/timepicker/timepicker.spec.js
+++ b/test/timepicker/timepicker.spec.js
@@ -527,7 +527,7 @@ describe('Set selectable range', function() {
     expect(selectOptions).toMatchObject(unrangedMins);
   });
 
-  it('should set time to range begin if it is later than setted time', function() {
+  it('should set time to range begin if it is later than set time', function() {
     var start = makeRangeObj(10, 35);
 
     timepickerNoMeridiem.setTime(9, 30);
@@ -537,7 +537,7 @@ describe('Set selectable range', function() {
     expect(timepickerNoMeridiem.getMinute()).toBe(35);
   });
 
-  it('should not reset time if the time which is begin of range is earlier than setted time', function() {
+  it('should not reset time if the time which is begin of range is earlier than set time', function() {
     var start = makeRangeObj(8, 35);
 
     timepickerNoMeridiem.setTime(9, 30);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Fix ​an issue where when setting a range, the time would be reset to the start time of the range regardless of the set time

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
