### PR TITLE
fix: set wrong time when setting time range if use time step (fix #65)

### DIFF
--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -768,16 +768,16 @@ var TimePicker = defineClass(
      * @private
      */
     applyRange: function(beginHour, beginMin, endHour) {
-      var toSetHour = beginHour;
-      var toSetMinute = Math.ceil(beginMin / this.minuteStep) * this.minuteStep;
+      var targetHour = beginHour;
+      var targetMinute = Math.ceil(beginMin / this.minuteStep) * this.minuteStep;
 
       if (this.isLaterThanSetTime(beginHour, beginMin)) {
         if (this.hourStep !== 1 && beginHour % this.hourStep !== 1) {
-          toSetHour = beginHour + (beginHour % this.hourStep) + 1;
-          toSetMinute = 0;
+          targetHour = beginHour + (beginHour % this.hourStep) + 1;
+          targetMinute = 0;
         }
 
-        this.setTime(toSetHour, toSetMinute);
+        this.setTime(targetHour, targetMinute);
       }
       this.setDisabledHours();
 

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -749,15 +749,15 @@ var TimePicker = defineClass(
         });
 
         if (beginHour === endHour) {
-          this.disabledMinutes[beginHour] = util.getDisabledMinuteArr(disabledMinRanges).slice();
+          this.disabledMinutes[beginHour] = util.getDisabledMinuteArr(disabledMinRanges, this.minuteStep).slice();
 
           return;
         }
 
-        this.disabledMinutes[endHour] = util.getDisabledMinuteArr([disabledMinRanges[1]]).slice();
+        this.disabledMinutes[endHour] = util.getDisabledMinuteArr([disabledMinRanges[1]], this.minuteStep).slice();
       }
 
-      this.disabledMinutes[beginHour] = util.getDisabledMinuteArr([disabledMinRanges[0]]).slice();
+      this.disabledMinutes[beginHour] = util.getDisabledMinuteArr([disabledMinRanges[0]], this.minuteStep).slice();
     },
 
     /**
@@ -768,8 +768,16 @@ var TimePicker = defineClass(
      * @private
      */
     applyRange: function(beginHour, beginMin, endHour) {
+      var toSetHour = beginHour;
+      var toSetMinute = Math.ceil(beginMin / this.minuteStep) * this.minuteStep;
+
       if (this.isLaterThanSetTime(beginHour, beginMin)) {
-        this.setTime(beginHour, beginMin);
+        if (this.hourStep !== 1 && beginHour % this.hourStep !== 1) {
+          toSetHour = beginHour + (beginHour % this.hourStep) + 1;
+          toSetMinute = 0;
+        }
+
+        this.setTime(toSetHour, toSetMinute);
       }
       this.setDisabledHours();
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -129,11 +129,14 @@ var utils = {
    * Get disabled minute array
    * @param {Array} enableRanges array of object which contains range
    */
-  getDisabledMinuteArr: function(enableRanges) {
-    var arr = this.fill(0, 60, false);
+  getDisabledMinuteArr: function(enableRanges, minuteStep) {
+    var arr = this.fill(0, Math.floor(60 / minuteStep) - 2, false);
 
     function setDisabled(enableRange) {
-      arr = this.fill(enableRange.begin, enableRange.end, true, arr);
+      var beginDisabledMinute = Math.ceil(enableRange.begin / minuteStep);
+      var endDisabledMinute = Math.floor(enableRange.end / minuteStep);
+
+      arr = this.fill(beginDisabledMinute, endDisabledMinute, true, arr);
     }
 
     forEachArray(enableRanges, setDisabled.bind(this));

--- a/test/timepicker/timepicker.spec.js
+++ b/test/timepicker/timepicker.spec.js
@@ -555,4 +555,14 @@ describe('Set selectable range', function() {
 
     expect(timepickerMeridiem.pmEl.disabled).toBe(true);
   });
+
+  it('should set selectable time when use minute step', function() {
+    var start = makeRangeObj(10, 35);
+
+    timepickerNoMeridiem.setTime(9, 30);
+    timepickerNoMeridiem.setMinuteStep(2);
+    timepickerNoMeridiem.setRange(start);
+
+    expect(timepickerNoMeridiem.getMinute()).toBe(36);
+  });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Fix the problem that set wrong time when setting time range if use time step
  - resolve #65 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
