### PR TITLE
feat: add `silent` option on setTime API for preventing firing `change` event

### DIFF
--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -627,7 +627,7 @@ var TimePicker = defineClass(
      * Set time
      * @param {number} hour for time picker - (0~23)
      * @param {number} minute for time picker
-     * @param {boolean} silent if it set true, 'change' event will not be fired.
+     * @param {boolean} [silent] if it set true, 'change' event will not be fired.
      */
     setTime: function(hour, minute, silent) {
       if (!this.validItems(hour, minute)) {

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -441,8 +441,9 @@ var TimePicker = defineClass(
     /**
      * Set values in spinboxes from time
      * @private
+     * @param {boolean} silent flag for firing 'change' event
      */
-    syncToInputs: function() {
+    syncToInputs: function(silent) {
       var hour = this.hour;
       var minute = this.minute;
 
@@ -450,8 +451,8 @@ var TimePicker = defineClass(
         hour = util.getMeridiemHour(hour);
       }
 
-      this.hourInput.setValue(hour);
-      this.minuteInput.setValue(minute);
+      this.hourInput.setValue(hour, silent);
+      this.minuteInput.setValue(minute, silent);
     },
 
     /**
@@ -626,8 +627,9 @@ var TimePicker = defineClass(
      * Set time
      * @param {number} hour for time picker - (0~23)
      * @param {number} minute for time picker
+     * @param {boolean} silent if it set true, 'change' event will not be fired.
      */
-    setTime: function(hour, minute) {
+    setTime: function(hour, minute, silent) {
       if (!this.validItems(hour, minute)) {
         return;
       }
@@ -635,7 +637,7 @@ var TimePicker = defineClass(
       this.hour = hour;
       this.minute = minute;
 
-      this.syncToInputs();
+      this.syncToInputs(silent);
       if (this.showMeridiem) {
         this.syncToMeridiemElements();
       }
@@ -651,10 +653,12 @@ var TimePicker = defineClass(
        *   console.log(e.hour, e.minute);
        * });
        */
-      this.fire('change', {
-        hour: this.hour,
-        minute: this.minute
-      });
+      if (!silent) {
+        this.fire('change', {
+          hour: this.hour,
+          minute: this.minute
+        });
+      }
     },
 
     /**
@@ -902,6 +906,7 @@ var TimePicker = defineClass(
       this.removeEvents();
       removeElement(this.element);
 
+      // eslint-disable-next-line max-len
       this.container = this.showMeridiem = this.hourInput = this.minuteInput = this.hour = this.minute = this.inputType = this.element = this.meridiemElement = this.amEl = this.pmEl = null;
     }
   }

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -441,7 +441,7 @@ var TimePicker = defineClass(
     /**
      * Set values in spinboxes from time
      * @private
-     * @param {boolean} silent flag for firing 'change' event
+     * @param {boolean} silent prevents firing 'change' event if it is true.
      */
     syncToInputs: function(silent) {
       var hour = this.hour;

--- a/src/js/timepicker/selectbox.js
+++ b/src/js/timepicker/selectbox.js
@@ -172,7 +172,7 @@ var Selectbox = defineClass(
     /**
      * Set new value
      * @private
-     * @param {boolean} silent flag for firing 'change' event
+     * @param {boolean} silent prevents firing 'change' event if it is true.
      */
     _setNewValue: function(silent) {
       var newValue = Number(this._element.value);
@@ -195,7 +195,7 @@ var Selectbox = defineClass(
     /**
      * Set value
      * @param {number} value - New value
-     * @param {boolean} silent - flag for firing 'change' event
+     * @param {boolean} silent - prevents firing 'change' event if it is true.
      */
     setValue: function(value, silent) {
       var newIndex = inArray(value, this._items);

--- a/src/js/timepicker/selectbox.js
+++ b/src/js/timepicker/selectbox.js
@@ -172,13 +172,16 @@ var Selectbox = defineClass(
     /**
      * Set new value
      * @private
+     * @param {boolean} silent flag for firing 'change' event
      */
-    _setNewValue: function() {
+    _setNewValue: function(silent) {
       var newValue = Number(this._element.value);
       this._selectedIndex = inArray(newValue, this._items);
-      this.fire('change', {
-        value: newValue
-      });
+      if (!silent) {
+        this.fire('change', {
+          value: newValue
+        });
+      }
     },
 
     /**
@@ -192,14 +195,15 @@ var Selectbox = defineClass(
     /**
      * Set value
      * @param {number} value - New value
+     * @param {boolean} silent - flag for firing 'change' event
      */
-    setValue: function(value) {
+    setValue: function(value, silent) {
       var newIndex = inArray(value, this._items);
 
       if (newIndex > -1 && newIndex !== this._selectedIndex) {
         this._selectedIndex = newIndex;
         this._element.value = value;
-        this._setNewValue();
+        this._setNewValue(silent);
       }
     },
 

--- a/src/js/timepicker/spinbox.js
+++ b/src/js/timepicker/spinbox.js
@@ -247,7 +247,7 @@ var Spinbox = defineClass(
     /**
      * Change value to input-box if it is valid.
      * @private
-     * @param {boolean} silent flag for firing 'change' event
+     * @param {boolean} silent prevents firing 'change' event if it is true.
      */
     _changeToInputValue: function(silent) {
       var newValue = Number(this._inputElement.value);
@@ -276,7 +276,7 @@ var Spinbox = defineClass(
     /**
      * Set value to input-box.
      * @param {number} value - Value
-     * @param {boolean} silent - flag for firing 'change' event
+     * @param {boolean} silent - prevents firing 'change' event if it is true.
      */
     setValue: function(value, silent) {
       this._inputElement.value = util.formatTime(value, this._format);

--- a/src/js/timepicker/spinbox.js
+++ b/src/js/timepicker/spinbox.js
@@ -247,8 +247,9 @@ var Spinbox = defineClass(
     /**
      * Change value to input-box if it is valid.
      * @private
+     * @param {boolean} silent flag for firing 'change' event
      */
-    _changeToInputValue: function() {
+    _changeToInputValue: function(silent) {
       var newValue = Number(this._inputElement.value);
       var newIndex = inArray(newValue, this._items);
 
@@ -260,22 +261,26 @@ var Spinbox = defineClass(
       }
 
       if (newIndex === -1) {
-        this.setValue(this._items[this._selectedIndex]);
+        this.setValue(this._items[this._selectedIndex], silent);
       } else {
         this._selectedIndex = newIndex;
-        this.fire('change', {
-          value: newValue
-        });
+
+        if (!silent) {
+          this.fire('change', {
+            value: newValue
+          });
+        }
       }
     },
 
     /**
      * Set value to input-box.
      * @param {number} value - Value
+     * @param {boolean} silent - flag for firing 'change' event
      */
-    setValue: function(value) {
+    setValue: function(value, silent) {
       this._inputElement.value = util.formatTime(value, this._format);
-      this._changeToInputValue();
+      this._changeToInputValue(silent);
     },
 
     /**

--- a/test/timepicker/timepicker.spec.js
+++ b/test/timepicker/timepicker.spec.js
@@ -562,3 +562,21 @@ describe('Set selectable range', function() {
     expect(timepickerNoMeridiem.getMinute()).toBe(36);
   });
 });
+
+describe('custom event', function() {
+  it('should fire change event when the value is changed', function() {
+    var spy = jest.fn();
+    timepickerNoMeridiem.on('change', spy);
+
+    timepickerNoMeridiem.setTime(10, 9);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should not fire change event when the value is changed', function() {
+    var spy = jest.fn();
+    timepickerNoMeridiem.on('change', spy);
+
+    timepickerNoMeridiem.setTime(10, 9, true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Added `silent` option on `setTime` API for preventing firing 'change' event.
  - If it set `true`, the 'change' event will not be firing.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
