### PR TITLE
fix: minute set to non-selectable minutes when changing selectable range

### DIFF
--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -757,23 +757,27 @@ var TimePicker = defineClass(
      * @private
      */
     applyRange: function(beginHour, beginMin, endHour) {
+      var targetMinuteIndex = Math.ceil(beginMin / this.minuteStep);
       var targetHour = beginHour;
-      var targetMinute = Math.ceil(beginMin / this.minuteStep) * this.minuteStep;
+      var targetMinute = targetMinuteIndex * this.minuteStep;
+      var diffFromSelectableMinute;
 
       if (this.isLaterThanSetTime(beginHour, beginMin)) {
-        if (this.hourStep !== 1 && beginHour % this.hourStep !== 1) {
-          targetHour = beginHour + (beginHour % this.hourStep) + 1;
-          targetMinute = 0;
-        }
-
-        if (this.disabledMinutes[targetHour][targetMinute]) {
-          targetMinute =
-            targetMinute +
+        if (this.disabledMinutes[targetHour][targetMinuteIndex]) {
+          diffFromSelectableMinute =
             this.disabledMinutes[targetHour]
-              .slice(targetMinute)
+              .slice(targetMinuteIndex)
               .findIndex(function(isMinuteDisabled) {
                 return !isMinuteDisabled;
-              });
+              }) * this.minuteStep;
+
+          targetMinute =
+            diffFromSelectableMinute >= 0 ? targetMinute + diffFromSelectableMinute : 60;
+        }
+
+        if ((this.hourStep !== 1 && beginHour % this.hourStep !== 1) || targetMinute >= 60) {
+          targetHour = beginHour + (beginHour % this.hourStep) + 1;
+          targetMinute = 0;
         }
 
         this.setTime(targetHour, targetMinute);

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -767,8 +767,19 @@ var TimePicker = defineClass(
           targetMinute = 0;
         }
 
+        if (this.disabledMinutes[targetHour][targetMinute]) {
+          targetMinute =
+            targetMinute +
+            this.disabledMinutes[targetHour]
+              .slice(targetMinute)
+              .findIndex(function(isMinuteDisabled) {
+                return !isMinuteDisabled;
+              });
+        }
+
         this.setTime(targetHour, targetMinute);
       }
+
       this.setDisabledHours();
       this.setDisabledMinutes(this.hour);
 

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -441,9 +441,8 @@ var TimePicker = defineClass(
     /**
      * Set values in spinboxes from time
      * @private
-     * @param {boolean} silent prevents firing 'change' event if it is true.
      */
-    syncToInputs: function(silent) {
+    syncToInputs: function() {
       var hour = this.hour;
       var minute = this.minute;
 
@@ -451,8 +450,8 @@ var TimePicker = defineClass(
         hour = util.getMeridiemHour(hour);
       }
 
-      this.hourInput.setValue(hour, silent);
-      this.minuteInput.setValue(minute, silent);
+      this.hourInput.setValue(hour, true);
+      this.minuteInput.setValue(minute, true);
     },
 
     /**
@@ -637,7 +636,7 @@ var TimePicker = defineClass(
       this.hour = hour;
       this.minute = minute;
 
-      this.syncToInputs(silent);
+      this.syncToInputs();
       if (this.showMeridiem) {
         this.syncToMeridiemElements();
       }

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -756,6 +756,7 @@ var TimePicker = defineClass(
      * @param {number} [endHour] - end hour of range
      * @private
      */
+    // eslint-disable-next-line complexity
     applyRange: function(beginHour, beginMin, endHour) {
       var targetMinuteIndex = Math.ceil(beginMin / this.minuteStep);
       var targetHour = beginHour;

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -575,7 +575,7 @@ var TimePicker = defineClass(
 
     /**
      * Set step of minute
-     * @param {array} step - Step to create items of minute
+     * @param {number} step - Step to create items of minute
      */
     setMinuteStep: function(step) {
       this.minuteStep = step;
@@ -707,10 +707,10 @@ var TimePicker = defineClass(
 
     /**
      * Set selectable range on minute
-     * @param {number} begin.hour - begin hour of range
-     * @param {number} begin.minute - begin minute of range
-     * @param {number} [end.hour] - end hour of range
-     * @param {number} [end.minute] - end minute of range
+     * @param {number} beginHour - begin hour of range
+     * @param {number} beginMin - begin minute of range
+     * @param {number} [endHour] - end hour of range
+     * @param {number} [endMin] - end minute of range
      * @private
      */
     setRangeMinute: function(beginHour, beginMin, endHour, endMin) {
@@ -751,9 +751,9 @@ var TimePicker = defineClass(
 
     /**
      * Apply range
-     * @param {number} begin.hour - begin hour of range
-     * @param {number} begin.minute - begin minute of range
-     * @param {number} [end.hour] - end hour of range
+     * @param {number} beginHour - begin hour of range
+     * @param {number} beginMin - begin minute of range
+     * @param {number} [endHour] - end hour of range
      * @private
      */
     applyRange: function(beginHour, beginMin, endHour) {

--- a/src/js/timepicker/index.js
+++ b/src/js/timepicker/index.js
@@ -691,8 +691,8 @@ var TimePicker = defineClass(
 
     /**
      * Set selectable range on hour
-     * @param {number} begin.hour - begin hour of range
-     * @param {number} [end.hour] - end hour of range
+     * @param {number} beginHour - begin hour of range
+     * @param {number} [endHour] - end hour of range
      * @private
      */
     setRangeHour: function(beginHour, endHour) {

--- a/test/timepicker/timepicker.spec.js
+++ b/test/timepicker/timepicker.spec.js
@@ -530,7 +530,7 @@ describe('Set selectable range', function() {
     timepickerNoMeridiem.setRange(start);
 
     expect(timepickerNoMeridiem.getHour()).toBe(10);
-    expect(timepickerNoMeridiem.getMinute()).toBe(35);
+    expect(timepickerNoMeridiem.getMinute()).toBe(36);
   });
 
   it('should not reset time if the time which is begin of range is earlier than set time', function() {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* Fixed an issue that the selected time was set to an unselectable time when the selected time was changed due to the range setting.
  * The time was set one minute earlier than the selectable range.
  * Also, when setting the hour and minute at the same time, a change event occurs when the hour changes, so the problem that the minute is not set correctly has been fixed.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
